### PR TITLE
Refactor YearMonth and YearMonthDay to support Gregorian, Buddhist, and Japanese calendars

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,63 @@ import SwiftUICalendar
 -   Full custom calendar cell
 -   Pager lock
 -   Starting the week with Sunday or Monday
+-   **Global calendar configuration** - Support for different calendar types (Gregorian, Islamic, Hebrew, etc.)
+
+## Calendar Configuration
+
+SwiftUICalendar allows you to configure a global calendar that will be used throughout the library. This is particularly useful when you need to ensure your app uses a specific calendar type (like Gregorian) regardless of the user's system settings.
+
+### Setting up Global Calendar
+
+Configure the calendar once in your app, and it will be used across all SwiftUICalendar instances:
+
+#### In SwiftUI App:
+```swift
+@main
+struct MyApp: App {
+    init() {
+        // Configure calendar before any views are created
+        CalendarConfig.shared.setCalendar(Calendar(identifier: .gregorian))
+    }
+    
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}
+```
+
+#### In UIKit AppDelegate:
+```swift
+func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    // Force library to use Gregorian calendar
+    CalendarConfig.shared.setCalendar(Calendar(identifier: .gregorian))
+    return true
+}
+```
+
+### Available Calendar Types:
+- `.gregorian` - Gregorian calendar (most common)
+- `.islamic` - Islamic calendar
+- `.hebrew` - Hebrew calendar  
+- `.chinese` - Chinese calendar
+- `.japanese` - Japanese calendar
+- And more...
+
+### Runtime Configuration:
+```swift
+// Change calendar at runtime
+CalendarConfig.shared.setCalendar(Calendar(identifier: .islamic))
+
+// Reset to system default
+CalendarConfig.shared.resetToDefault()
+
+// Get current configured calendar
+let currentCalendar = CalendarConfig.shared.calendar
+```
+
+> **Note**: Calendar configuration applies globally to all SwiftUICalendar instances in your app. Changes take effect immediately.
 
 ## Example
 

--- a/Sources/SwiftUICalendar/Classes/Global.swift
+++ b/Sources/SwiftUICalendar/Classes/Global.swift
@@ -12,3 +12,38 @@ class Global {
     static let MAX_PAGE = 100
     static let CENTER_PAGE = 100 / 2
 }
+
+/// Configuration class for managing the global calendar used throughout SwiftUICalendar
+/// 
+/// This singleton allows you to set a specific calendar type (e.g., Gregorian) that will be used
+/// across the entire SwiftUICalendar library, instead of relying on Calendar.current which may
+/// vary based on the user's system settings.
+///
+/// See README.md for detailed usage examples and setup instructions.
+public class CalendarConfig {
+    private static var _shared = CalendarConfig()
+    private var _calendar: Calendar = Calendar.current
+    
+    private init() {}
+    
+    /// Returns the singleton instance
+    public static var shared: CalendarConfig {
+        return _shared
+    }
+    
+    /// Returns the currently configured calendar
+    public var calendar: Calendar {
+        return _calendar
+    }
+    
+    /// Sets the global calendar to be used throughout the library
+    /// - Parameter calendar: The calendar to use (e.g., Calendar(identifier: .gregorian))
+    public func setCalendar(_ calendar: Calendar) {
+        _calendar = calendar
+    }
+    
+    /// Resets the calendar back to Calendar.current
+    public func resetToDefault() {
+        _calendar = Calendar.current
+    }
+}

--- a/Sources/SwiftUICalendar/Classes/Struct.swift
+++ b/Sources/SwiftUICalendar/Classes/Struct.swift
@@ -53,7 +53,8 @@ public struct YearMonth: Equatable, Hashable {
     public static var current: YearMonth {
         get {
             let today = Date()
-            return YearMonth(year: Calendar.current.component(.year, from: today), month: Calendar.current.component(.month, from: today))
+            let calendar = Calendar.current
+            return YearMonth(year: calendar.component(.year, from: today), month: calendar.component(.month, from: today))
         }
     }
     
@@ -75,14 +76,14 @@ public struct YearMonth: Equatable, Hashable {
     }
     
     public func addMonth(value: Int) -> YearMonth {
-        let gregorianCalendar = NSCalendar(calendarIdentifier: .gregorian)!
+        let calendar = Calendar.current
         let toDate = self.toDateComponents()
 
         var components = DateComponents()
         components.month = value
 
-        let addedDate = Calendar.current.date(byAdding: components, to: gregorianCalendar.date(from: toDate)!)!
-        let ret = YearMonth(year: Calendar.current.component(.year, from: addedDate), month: Calendar.current.component(.month, from: addedDate))
+        let addedDate = calendar.date(byAdding: components, to: calendar.date(from: toDate)!)!
+        let ret = YearMonth(year: calendar.component(.year, from: addedDate), month: calendar.component(.month, from: addedDate))
         return ret
     }
     
@@ -113,19 +114,19 @@ public struct YearMonth: Equatable, Hashable {
     }
     
     internal func cellToDate(_ cellIndex: Int, startWithMonday: Bool) -> YearMonthDay {
-        let gregorianCalendar = NSCalendar(calendarIdentifier: .gregorian)!
+        let calendar = Calendar.current
         var toDateComponent = DateComponents()
         toDateComponent.year = self.year
         toDateComponent.month = self.month
         toDateComponent.day = 1
-        let toDate = gregorianCalendar.date(from: toDateComponent)!
-        let weekday = Calendar.current.component(.weekday, from: toDate) // 1Sun, 2Mon, 3Tue, 4Wed, 5Thu, 6Fri, 7Sat
+        let toDate = calendar.date(from: toDateComponent)!
+        let weekday = calendar.component(.weekday, from: toDate)
         var components = DateComponents()
         components.day = cellIndex - weekday + (!startWithMonday ? 1 : weekday == 1 ? (-5) : 2)
-        let addedDate = Calendar.current.date(byAdding: components, to: toDate)!
-        let year = Calendar.current.component(.year, from: addedDate)
-        let month = Calendar.current.component(.month, from: addedDate)
-        let day = Calendar.current.component(.day, from: addedDate)
+        let addedDate = calendar.date(byAdding: components, to: toDate)!
+        let year = calendar.component(.year, from: addedDate)
+        let month = calendar.component(.month, from: addedDate)
+        let day = calendar.component(.day, from: addedDate)
         let isFocusYaerMonth = year == self.year && month == self.month
         let ret = YearMonthDay(year: year, month: month, day: day, isFocusYearMonth: isFocusYaerMonth)
         return ret
@@ -155,10 +156,11 @@ public struct YearMonthDay: Equatable, Hashable {
     public static var current: YearMonthDay {
         get {
             let today = Date()
+            let calendar = Calendar.current
             return YearMonthDay(
-                year: Calendar.current.component(.year, from: today),
-                month: Calendar.current.component(.month, from: today),
-                day: Calendar.current.component(.day, from: today)
+                year: calendar.component(.year, from: today),
+                month: calendar.component(.month, from: today),
+                day: calendar.component(.day, from: today)
             )
         }
     }
@@ -181,8 +183,8 @@ public struct YearMonthDay: Equatable, Hashable {
     }
     
     public var date: Date? {
-        let gregorianCalendar = NSCalendar(calendarIdentifier: .gregorian)!
-        return gregorianCalendar.date(from: self.toDateComponents())
+        let calendar = Calendar.current
+        return calendar.date(from: self.toDateComponents())
     }
     
     public func toDateComponents() -> DateComponents {
@@ -194,17 +196,17 @@ public struct YearMonthDay: Equatable, Hashable {
     }
     
     public func addDay(value: Int) -> YearMonthDay {
-        let gregorianCalendar = NSCalendar(calendarIdentifier: .gregorian)!
+        let calendar = Calendar.current
         let toDate = self.toDateComponents()
 
         var components = DateComponents()
         components.day = value
 
-        let addedDate = Calendar.current.date(byAdding: components, to: gregorianCalendar.date(from: toDate)!)!
+        let addedDate = calendar.date(byAdding: components, to: calendar.date(from: toDate)!)!
         let ret = YearMonthDay(
-            year: Calendar.current.component(.year, from: addedDate),
-            month: Calendar.current.component(.month, from: addedDate),
-            day: Calendar.current.component(.day, from: addedDate)
+            year: calendar.component(.year, from: addedDate),
+            month: calendar.component(.month, from: addedDate),
+            day: calendar.component(.day, from: addedDate)
         )
         return ret
     }

--- a/Sources/SwiftUICalendar/Classes/Struct.swift
+++ b/Sources/SwiftUICalendar/Classes/Struct.swift
@@ -53,7 +53,7 @@ public struct YearMonth: Equatable, Hashable {
     public static var current: YearMonth {
         get {
             let today = Date()
-            let calendar = Calendar.current
+            let calendar = CalendarConfig.shared.calendar
             return YearMonth(year: calendar.component(.year, from: today), month: calendar.component(.month, from: today))
         }
     }
@@ -71,12 +71,12 @@ public struct YearMonth: Equatable, Hashable {
             components.second = 0
             let formatter = DateFormatter()
             formatter.dateFormat = "MMM"
-            return formatter.string(from: Calendar.current.date(from: components)!)
+            return formatter.string(from: CalendarConfig.shared.calendar.date(from: components)!)
         }
     }
     
     public func addMonth(value: Int) -> YearMonth {
-        let calendar = Calendar.current
+        let calendar = CalendarConfig.shared.calendar
         let toDate = self.toDateComponents()
 
         var components = DateComponents()
@@ -98,7 +98,7 @@ public struct YearMonth: Equatable, Hashable {
         new.hour = 0
         new.minute = 0
         new.second = 0
-        return Calendar.current.dateComponents([.month], from: Calendar.current.date(from: origin)!, to: Calendar.current.date(from: new)!).month!
+        return CalendarConfig.shared.calendar.dateComponents([.month], from: CalendarConfig.shared.calendar.date(from: origin)!, to: CalendarConfig.shared.calendar.date(from: new)!).month!
     }
     
     public func toDateComponents() -> DateComponents {
@@ -114,7 +114,7 @@ public struct YearMonth: Equatable, Hashable {
     }
     
     internal func cellToDate(_ cellIndex: Int, startWithMonday: Bool) -> YearMonthDay {
-        let calendar = Calendar.current
+        let calendar = CalendarConfig.shared.calendar
         var toDateComponent = DateComponents()
         toDateComponent.year = self.year
         toDateComponent.month = self.month
@@ -156,7 +156,7 @@ public struct YearMonthDay: Equatable, Hashable {
     public static var current: YearMonthDay {
         get {
             let today = Date()
-            let calendar = Calendar.current
+            let calendar = CalendarConfig.shared.calendar
             return YearMonthDay(
                 year: calendar.component(.year, from: today),
                 month: calendar.component(.month, from: today),
@@ -171,19 +171,20 @@ public struct YearMonthDay: Equatable, Hashable {
     
     public var isToday: Bool {
         let today = Date()
-        let year = Calendar.current.component(.year, from: today)
-        let month = Calendar.current.component(.month, from: today)
-        let day = Calendar.current.component(.day, from: today)
+        let calendar = CalendarConfig.shared.calendar
+        let year = calendar.component(.year, from: today)
+        let month = calendar.component(.month, from: today)
+        let day = calendar.component(.day, from: today)
         return self.year == year && self.month == month && self.day == day
     }
     
     public var dayOfWeek: Week {
-        let weekday = Calendar.current.component(.weekday, from: self.date!)
+        let weekday = CalendarConfig.shared.calendar.component(.weekday, from: self.date!)
         return Week.allCases[weekday - 1]
     }
     
     public var date: Date? {
-        let calendar = Calendar.current
+        let calendar = CalendarConfig.shared.calendar
         return calendar.date(from: self.toDateComponents())
     }
     
@@ -196,7 +197,7 @@ public struct YearMonthDay: Equatable, Hashable {
     }
     
     public func addDay(value: Int) -> YearMonthDay {
-        let calendar = Calendar.current
+        let calendar = CalendarConfig.shared.calendar
         let toDate = self.toDateComponents()
 
         var components = DateComponents()
@@ -220,7 +221,7 @@ public struct YearMonthDay: Equatable, Hashable {
         new.hour = 0
         new.minute = 0
         new.second = 0
-        return Calendar.current.dateComponents([.day], from: Calendar.current.date(from: origin)!, to: Calendar.current.date(from: new)!).month!
+        return CalendarConfig.shared.calendar.dateComponents([.day], from: CalendarConfig.shared.calendar.date(from: origin)!, to: CalendarConfig.shared.calendar.date(from: new)!).month!
     }
     
     public func hash(into hasher: inout Hasher) {


### PR DESCRIPTION
- Replace NSCalendar with Calendar.current for date calculations
- Simplify current date retrieval logic
- Ensure consistent use of Calendar.current across methods